### PR TITLE
Handle syntax errors and display them using linter

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -66,21 +66,42 @@ function refmt (editor, parse = 're', format = 're') {
 
 async function format (editor) {
   editor = editor || atom.workspace.getActiveTextEditor()
-  const text = await refmt(editor)
-  setText(editor, text)
+  try {
+    const text = await refmt(editor)
+    setText(editor, text)
+  } catch (err) {
+    const parsedError = parseRefmtError(err)
+    if (!parsedError) {
+      throw err
+    }
+  }
 }
 
 async function convertToReason () {
   let editor = atom.workspace.getActiveTextEditor()
-  const text = await refmt(editor, 'ml', 're')
-  const uri = editor.getPath() && editor.getPath().replace(/\.ml(i?)$/, '.re$1')
-  editor = await atom.workspace.open(uri)
-  editor.setText(text)
+  try {
+    const text = await refmt(editor, 'ml', 're')
+    const uri = editor.getPath() && editor.getPath().replace(/\.ml(i?)$/, '.re$1')
+    editor = await atom.workspace.open(uri)
+    editor.setText(text)
+  } catch (err) {
+    const parsedError = parseRefmtError(err)
+    if (!parsedError) {
+      throw err
+    }
+  }
 }
 
 async function convertToOCaml () {
   let editor = atom.workspace.getActiveTextEditor()
-  const text = await refmt(editor, 're', 'ml')
+  try {
+    const text = await refmt(editor, 're', 'ml')
+  } catch (err) {
+    const parsedError = parseRefmtError(err)
+    if (!parsedError) {
+      throw err
+    }
+  }
   const uri = editor.getPath() && editor.getPath().replace(/\.re(i?)$/, '.ml$1')
   editor = await atom.workspace.open(uri)
   editor.setText(text)
@@ -114,6 +135,24 @@ function setText (editor, text) {
   }))
 }
 
+function parseRefmtError(error) {
+  if (typeof error !== 'string') {
+    return null
+  }
+  const match = error.match(/^File ".*?", line (\d+), characters (\d+)-(\d+):\n([\s\S]*)/)
+  if (match) {
+    const range = [
+      [parseInt(match[1]) - 1, parseInt(match[2])],
+      [parseInt(match[1]) - 1, parseInt(match[3])],
+    ]
+    return {
+      text: match[4].trim(),
+      range,
+    };
+  }
+  return null
+}
+
 export function provideLinter () {
   return {
     name: 'refmt',
@@ -123,17 +162,31 @@ export function provideLinter () {
     async lint (editor) {
       const messages = []
       if (atom.config.get('reason-refmt.useLinter')) {
-        const text = await refmt(editor)
-        diff(editor.getText(), text, (range) => {
-          if (range[0] !== range[1]) {
+        try {
+          const text = await refmt(editor)
+          diff(editor.getText(), text, (range) => {
+            if (range[0] !== range[1]) {
+              messages.push({
+                type: 'Warning',
+                text: 'Wrong formatting',
+                range,
+                filePath: editor.getPath()
+              })
+            }
+          })
+        } catch (err) {
+          const parsedError = parseRefmtError(err)
+          if (parsedError) {
             messages.push({
-              type: 'Warning',
-              text: 'Wrong formatting',
-              range,
-              filePath: editor.getPath()
+              type: 'Error',
+              text: parsedError.text,
+              range: parsedError.range,
+              filePath: editor.getPath(),
             })
+          } else {
+            throw err
           }
-        })
+        }
       }
       return messages
     }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "useLinter": {
       "type": "boolean",
-      "default": false
+      "default": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
This PR handles the case where refmt is used on code with syntax errors, and adds support for displaying those errors with Linter.

I'm making this PR to deal with two related issues:
1. Currently this package has unhandled promise rejections when a Reason file with a syntax error is formatted. I've added handling for this case in this PR.
2. The errors provided by Merlin are not great for many Reason syntax errors. Often the Merlin error location will be much later in the file than where the actual syntax error occurred. Refmt is a better source of syntax error information for Reason. Thus I've added support for outputting these errors to Linter, and changed Linter integration to be enabled by default.

I realise this is somewhat different to the existing use of Linter in this package, and also expands the purpose of this package from simply formatting to both formatting and syntax error reporting, however, as syntax errors are currently an essential function of refmt it seems appropriate to me.

### Screencast
![refmt-syntax-error mov](https://cloud.githubusercontent.com/assets/1232587/26764474/59932e46-491c-11e7-85fe-074272e6a61d.gif)
