### PR TITLE
fix condition to allow interface arg to be set correctly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,7 @@ function refmt (editor, text, parse = 're', format = 're', silent = false) {
   const command = atom.config.get('reason-refmt.refmtPath')
   const width = atom.config.get('editor.preferredLineLength')
   const isInterface =
-    editor.getPath() && editor.getPath().match(/\.(re|ml)i$/) != null
+    !!editor.getPath() && editor.getPath().match(/\.(re|ml)i$/) != null
   const args = [
     `--interface=${isInterface}`,
     `--print=${format}`,


### PR DESCRIPTION
`editor.getPath()` returns `undefined` which results in an error being thrown when saving a new Reason file. This adds `!!` in front of `editor.getPath()` which will turn it `false` on when that function returns `undefined`. It eventually sets `isInterface` to `false`, allowing the save to happen.

Closes #11.