### PR TITLE
Add instructions to readme on how to start development

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["standard"],
   "rules": {
-    "no-debugger": 0
+    "no-debugger": 1
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": ["standard"]
+  "extends": ["standard"],
+  "rules": {
+    "no-debugger": 0
+  }
 }

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ To start hacking on this package, run:
 $ apm dev reason-refmt
 ```
 
-This clones the git repo into `~/.atom/dev/packages/reason-refmt`, and installs it as as packge into Atom. Then to begin development run:
+This clones the git repo into `~/.atom/dev/packages/reason-refmt`, and installs it as as packge into Atom as a Development Package. To begin development, start editing the package code:
 
 ```
 $ atom ~/.atom/dev/packages/reason-refmt
 ```
 
-Now you can edit the package source code. When you make changes, be sure to call up the Command Palette and run `Window: Reload` to reload your changes.
+When you make changes, be sure to call up the Command Palette and reload the editor to see your changes with `Window: Reload`.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ apm install language-reason reason-refmt ocaml-merlin linter
 [language-reason]: https://atom.io/packages/language-reason
 [refmt]: https://reasonml.github.io/guide/editor-tools/global-installation/#recommended-through-npmyarn
 [ocaml-merlin]: https://atom.io/packages/ocaml-merlin
+
+## Development
+
+To start hacking on this package, run:
+
+```
+$ apm dev reason-refmt
+```
+
+This clones the git repo into `~/.atom/dev/packages/reason-refmt`, and installs it as as packge into Atom. Then to begin development run:
+
+```
+$ atom ~/.atom/dev/packages/reason-refmt
+```
+
+Now you can edit the package source code. When you make changes, be sure to call up the Command Palette and run `Window: Reload` to reload your changes.


### PR DESCRIPTION
This adds some instructions on how to start hacking on the package. This diff also allows the `debugger` command to appear in the code, albeit as a warning. This was something new to me on how to start testing my changes and I think it could help anyone who wants to contribute.